### PR TITLE
Fix: Sometimes the DB_SCHEMA_%s macros are generated such that they w…

### DIFF
--- a/protos.c
+++ b/protos.c
@@ -590,14 +590,15 @@ void
 print_define_schema(const struct strct *p)
 {
 	const struct field *f;
+	const char *s = "";
 
-	printf("#define DB_SCHEMA_%s(_x) \\\n", p->cname);
+	printf("#define DB_SCHEMA_%s(_x) \\", p->cname);
 	TAILQ_FOREACH(f, &p->fq, entries) {
 		if (FTYPE_STRUCT == f->type)
 			continue;
+		puts(s);
 		printf("\t#_x \".%s\"", f->name);
-		if (TAILQ_NEXT(f, entries))
-			puts(" \",\" \\");
+		s = " \",\" \\";
 	}
 	puts("");
 }


### PR DESCRIPTION
Fix: Sometimes the DB_SCHEMA_%s macros are generated such that they would be continuing after the last line.

First consider the following (modified) example: 

```
struct user {
  field name text null comment "full name (or null)";
  field email text unique comment "unique e-mail";
  field hash password comment "hashed password";
  field id int rowid comment "unique identifier";
  search id: comment "search by user identifier";
  search email,hash: name creds comment "lookup by credentials";
  comment "a system user";
};

struct session {
  field uid:user.id int comment "user bound to session";
  field token int comment "unique session token";
  field id int rowid;
  field user struct uid;
  comment "web session";
};
```

Without the patch, a part of the code generated by `ort-c-header` is the following:
```
/*
 * Define our table columns.
 * Use these when creating your own SQL statements, combined with the 
 * db_xxxx_fill functions.
 * Each macro must be given a unique alias name.
 * This allows for doing multiple inner joins on the same table.
 */
#define DB_SCHEMA_USER(_x) \
        #_x ".name" "," \
        #_x ".email" "," \
        #_x ".hash" "," \
        #_x ".id"
#define DB_SCHEMA_SESSION(_x) \
        #_x ".uid" "," \
        #_x ".token" "," \
        #_x ".id" "," \


__BEGIN_DECLS
```

With the patch, the same part of the code is the following:
```
/*
 * Define our table columns.
 * Use these when creating your own SQL statements, combined with the 
 * db_xxxx_fill functions.
 * Each macro must be given a unique alias name.
 * This allows for doing multiple inner joins on the same table.
 */
#define DB_SCHEMA_USER(_x) \
        #_x ".name" "," \
        #_x ".email" "," \
        #_x ".hash" "," \
        #_x ".id"
#define DB_SCHEMA_SESSION(_x) \
        #_x ".uid" "," \
        #_x ".token" "," \
        #_x ".id"

__BEGIN_DECLS
```