### PR TITLE
Let db_open_logging err if database does not exist

### DIFF
--- a/lang-c-source.c
+++ b/lang-c-source.c
@@ -1050,7 +1050,7 @@ gen_open(FILE *f, const struct config *cfg)
 		return 0;
 
 	if (fputs("\n"
-	    "\tif (sqlbox_open_async(db, 0))\n"
+	    "\tif (sqlbox_open_async(db, 0) && sqlbox_ping(db))\n"
 	    "\t\treturn ctx;\n"
 	    "err:\n", f) == EOF)
 		return 0;


### PR DESCRIPTION
sqlbox_open_async communication with box succeeds, even if the database does not exist. Add a sqlbox_ping check to verify database could actually be opened.

I am not sure if this change is wanted / correct. I was playing around with kcgi-framework and noticed that it checks the database connection in https://github.com/kristapsdz/kcgi-framework/blob/master/main.c#L270
The issue with that is: When the database doesn't exist, `r.arg` is not  `NULL`.

Alternatively maybe a db_ping function should be provided, to check if the database was successfully opened?